### PR TITLE
feat(frontend): connect to backend health endpoint

### DIFF
--- a/frontend/menus/hackathon/README.md
+++ b/frontend/menus/hackathon/README.md
@@ -16,6 +16,10 @@ bun dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
+## Environment variables
+
+Create a `.env.local` file and set `NEXT_PUBLIC_API_BASE_URL` with the URL of the backend (e.g. `http://localhost:8000`).
+
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.

--- a/frontend/menus/hackathon/app/page.tsx
+++ b/frontend/menus/hackathon/app/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import Pentagon from '../components/Pentagon'; // ajusta la ruta según donde esté tu componente
 import ChatAI from '../components/ChatAI';     // aquí parecía estar en ../../ChatAI, asegúrate que sea correcta
 import React from 'react';
+import BackendStatus from '../components/BackendStatus';
 
 export default function HomePage() {
   const skills = [
@@ -26,6 +27,7 @@ export default function HomePage() {
       <header className="dashboard-header">
         <h1 className="dashboard-title">Dashboard del Futuro</h1>
         <p className="dashboard-subtitle">Un nuevo camino para tu desarrollo.</p>
+        <BackendStatus />
       </header>
 
       <div className="grid-layout">

--- a/frontend/menus/hackathon/components/BackendStatus.tsx
+++ b/frontend/menus/hackathon/components/BackendStatus.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getHealth } from '../lib/api';
+
+export default function BackendStatus() {
+  const [status, setStatus] = useState<string>('cargando...');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getHealth()
+      .then((data) => setStatus(data.status))
+      .catch((err) => setError(err.message));
+  }, []);
+
+  if (error) {
+    return <p>Error al conectar: {error}</p>;
+  }
+
+  return <p>Estado del backend: {status}</p>;
+}

--- a/frontend/menus/hackathon/lib/api.ts
+++ b/frontend/menus/hackathon/lib/api.ts
@@ -1,0 +1,9 @@
+export const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+
+export async function getHealth() {
+  const res = await fetch(`${apiBaseUrl}/health/live`);
+  if (!res.ok) {
+    throw new Error('Failed to fetch health');
+  }
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- add API helper to call backend health endpoint
- display backend status on dashboard
- document required NEXT_PUBLIC_API_BASE_URL env variable

## Testing
- `npm test` (fails: Missing script: "test")
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/@tailwindcss%2fpostcss)
- `npm run lint` (fails: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_68a17b43ec14832787ac768d5c393eee